### PR TITLE
use the proxy's url if available

### DIFF
--- a/lib/Plack/Middleware/Auth/Digest.pm
+++ b/lib/Plack/Middleware/Auth/Digest.pm
@@ -36,7 +36,12 @@ sub call {
         my $auth = $self->parse_challenge($1) || {};
         $auth->{method} = $env->{REQUEST_METHOD};
 
-        if ($auth->{uri} ne $env->{REQUEST_URI}) {
+        my $checkUrl = $env->{REQUEST_URI};
+        if($env->{HTTP_X_FORWARDED_SCRIPT_NAME}){
+            $checkUrl = $env->{HTTP_X_FORWARDED_SCRIPT_NAME} . $env->{REQUEST_URI};
+        }
+
+        if ($auth->{uri} ne $checkUrl) {
             return [ 400, ['Content-Type', 'text/plain'], [ "Bad Request" ] ];
         }
 


### PR DESCRIPTION
When a PSGI app is used behind a reverse proxy the the URL that the client uses can be different from the app's URL, which will normally break digest auth.

Here's a small fix that solves my setup, maybe this fix could be made more generic?
